### PR TITLE
Adds option to configure authorization URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Latest Version](https://img.shields.io/github/release/adam-paterson/oauth2-stripe.svg?style=flat-square)](https://github.com/adam-paterson/oauth2-stripe/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/adam-paterson/oauth2-stripe/master.svg?style=flat-square)](https://travis-ci.org/adam-paterson/oauth2-stripe)
-[![HHVM Status](https://img.shields.io/hhvm/adam-paterson/oauth2-stripe.svg?style=flat-square)](http://hhvm.h4cc.de/package/adam-paterson/oauth2-stripe)
 [![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/adam-paterson/oauth2-stripe.svg?style=flat-square)](https://scrutinizer-ci.com/g/adam-paterson/oauth2-stripe/code-structure)
 [![Quality Score](https://img.shields.io/scrutinizer/g/adam-paterson/oauth2-stripe.svg?style=flat-square)](https://scrutinizer-ci.com/g/adam-paterson/oauth2-stripe)
 [![Dependency Status](https://img.shields.io/versioneye/d/php/adam-paterson:oauth2-stripe/1.1.2.svg?style=flat-square)](https://www.versioneye.com/php/adam-paterson:oauth2-stripe/1.1.2)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ if (!isset($_GET['code'])) {
 
 ```
 
+### Set a custom `baseUrl`
+
+For example, this for use with Stripe Connect Express accounts:
+
+```php
+$provider = new \AdamPaterson\OAuth2\Client\Provider\Stripe([
+    'clientId'          => '{stripe-client-id}',
+    'clientSecret'      => '{stripe-client-secret}',
+    'baseUrl'           => 'https://connect.stripe.com/express/',
+]);
+```
+
 ## Testing
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ if (!isset($_GET['code'])) {
 
 ```
 
-### Set a custom `baseUrl`
+### Set a custom `urlAuthorize`
 
 For example, this for use with Stripe Connect Express accounts:
 
@@ -83,7 +83,7 @@ For example, this for use with Stripe Connect Express accounts:
 $provider = new \AdamPaterson\OAuth2\Client\Provider\Stripe([
     'clientId'          => '{stripe-client-id}',
     'clientSecret'      => '{stripe-client-secret}',
-    'baseUrl'           => 'https://connect.stripe.com/express/',
+    'urlAuthorize'      => 'https://connect.stripe.com/express/oauth/authorize',
 ]);
 ```
 

--- a/src/Provider/Stripe.php
+++ b/src/Provider/Stripe.php
@@ -16,7 +16,7 @@ class Stripe extends AbstractProvider
     /**
      * @var string
      */
-    private $urlAuthorize = 'https://connect.stripe.com/oauth/authorize';
+    public $urlAuthorize = 'https://connect.stripe.com/oauth/authorize';
 
     /**
      * Get authorization url to begin OAuth flow

--- a/src/Provider/Stripe.php
+++ b/src/Provider/Stripe.php
@@ -14,13 +14,18 @@ class Stripe extends AbstractProvider
     use BearerAuthorizationTrait;
 
     /**
+     * @var string
+     */
+    private $urlAuthorize = 'https://connect.stripe.com/oauth/authorize';
+
+    /**
      * Get authorization url to begin OAuth flow
      *
      * @return string
      */
     public function getBaseAuthorizationUrl()
     {
-        return 'https://connect.stripe.com/oauth/authorize';
+        return $this->urlAuthorize;
     }
 
     /**


### PR DESCRIPTION
This adds the option to change the base URL, which is needed to support [Stripe Connect with Express accounts](https://stripe.com/docs/connect/express-accounts). It leaves the current URL as the default.

It looks like at least one other person encountered changed this same thing [on their fork](https://github.com/terehru/oauth2-stripe/commit/94d6f5652e4bd468d12511eb0d6fe82cfea99dad), but from my understanding, this is the proper way for League providers to make that configurable.

The diff on the README license line is only for the line ending, sorry about that.

Thanks!